### PR TITLE
Return original image attributes if not on same domain

### DIFF
--- a/class-twicpics-api.php
+++ b/class-twicpics-api.php
@@ -152,7 +152,7 @@ class TwicPicsApi {
 		}
 
 		if ( ! $this->is_on_same_domain( $img_src ) ) {
-			return;
+			return $attributes;
 		}
 
 		/* TwicPics src*/

--- a/class-twicpics-script.php
+++ b/class-twicpics-script.php
@@ -230,7 +230,7 @@ class TwicPicsScript {
 		}
 
 		if ( ! $this->is_on_same_domain( $img_url ) ) {
-			return;
+			return $attributes;
 		}
 
 		$attributes['data-twic-src'] = $this->_urls_manager->get_original_size_url( $img_url );


### PR DESCRIPTION
This PR updates the image_attributes() method to ensure it returns the original $attributes array when an image is hosted on a different domain. Otherwise WP will break and throw an error

` PHP Fatal error:  Uncaught TypeError: array_map(): Argument #2 ($array) must be of type array, null given in .../wp-includes/media.php:1172`